### PR TITLE
Fixed drawing error of trace lines

### DIFF
--- a/object_tracking.py
+++ b/object_tracking.py
@@ -75,9 +75,9 @@ def main():
                     for j in range(len(tracker.tracks[i].trace)-1):
                         # Draw trace line
                         x1 = tracker.tracks[i].trace[j][0][0]
-                        y1 = tracker.tracks[i].trace[j][1][0]
-                        x2 = tracker.tracks[i].trace[j+1][0][0]
-                        y2 = tracker.tracks[i].trace[j+1][1][0]
+                        y1 = tracker.tracks[i].trace[j][0][1]
+                        x2 = tracker.tracks[i].trace[j+1][1][0]
+                        y2 = tracker.tracks[i].trace[j+1][1][1]
                         clr = tracker.tracks[i].track_id % 9
                         cv2.line(frame, (int(x1), int(y1)), (int(x2), int(y2)),
                                  track_colors[clr], 2)


### PR DESCRIPTION
Under "# Draw trace line" the variable assignments are mixed up:
x1 = [0][0] =corrected=> [0][0]
y1 = [1][0] =corrected=> [0][1]
x2 = [0][0] =corrected=> [1][0]
y2 = [1][0] =corrected=> [1][1]